### PR TITLE
A little code coverage refactor

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,5 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-output-type: lcov
-output-file: ./lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,21 +20,19 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+          components: llvm-tools-preview
+      - name: Install grcov
+        run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
       - name: Prepare
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-targets --all-features --no-fail-fast
         env:
-          CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: >-
-            -Zprofile
-            -Ccodegen-units=1
-            -Cinline-threshold=0
-            -Clink-dead-code
-            -Coverflow-checks=off
+          RUSTFLAGS: -Zinstrument-coverage
+          LLVM_PROFILE_FILE: "carapax-%p-%m.profraw"
       - name: Aggregate
-        uses: actions-rs/grcov@v0.1
+        run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./lcov.info
       - name: Publish
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,10 +28,9 @@ jobs:
           curl -L https://github.com/Kogia-sima/rust-covfix/releases/download/v0.2.2/rust-covfix-linux-x86_64.tar.xz | tar Jxf -
           mv rust-covfix-linux-x86_64/rust-covfix ./
       - name: Prepare
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets --all-features --no-fail-fast
+        run: |
+          cargo build --all-targets --all-features
+          cargo test --all-targets --all-features --no-fail-fast
         env:
           RUSTFLAGS: -Zinstrument-coverage
           LLVM_PROFILE_FILE: "carapax-%p-%m.profraw"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
           RUSTFLAGS: -Zinstrument-coverage
           LLVM_PROFILE_FILE: "carapax-%p-%m.profraw"
       - name: Aggregate
-        run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./lcov.info
+        run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" --ignore "**/examples/*" -o ./lcov.info
       - name: Fix coverage info
         run: ./rust-covfix -o lcov.info lcov.info
       - name: Publish

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,10 @@ jobs:
           components: llvm-tools-preview
       - name: Install grcov
         run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+      - name: Install rust-covfix
+        run: |
+          curl -L https://github.com/Kogia-sima/rust-covfix/releases/download/v0.2.2/rust-covfix-linux-x86_64.tar.xz | tar Jxf -
+          mv rust-covfix-linux-x86_64/rust-covfix ./
       - name: Prepare
         uses: actions-rs/cargo@v1
         with:
@@ -33,6 +37,8 @@ jobs:
           LLVM_PROFILE_FILE: "carapax-%p-%m.profraw"
       - name: Aggregate
         run: ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./lcov.info
+      - name: Fix coverage info
+        run: ./rust-covfix -o lcov.info lcov.info
       - name: Publish
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
* Use source-based code coverage instead of gcov
* Download binaries instead of long compilation
* Use rust-covfix to get rid of incorrect lines