### PR TITLE
Update HandlerResult

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -94,7 +94,7 @@ let chain = Chain::default()
 ```
 
 Handlers will run in same order as added.
-If a handler returns `HandlerResult::Stop` or `HandlerResult::Error(_)`, all the subsequent handlers will not run.
+If a handler returns `HandlerResult::Err(_)`, all the subsequent handlers will not run.
 
 ### HandlerResult
 
@@ -102,9 +102,7 @@ Normally every handler must return a `HandlerResult` or a type that converts int
 
 | From            | To                          |
 |-----------------|-----------------------------|
-| `()`            | `HandlerResult::Stop`       |
-| `true`          | `HandlerResult::Continue`   |
-| `false`         | `HandlerResult::Stop`       |
+| `()`            | `HandlerResult::Ok`         |
 | `Result<T, E>`  | `T: Into<HandlerResult>`    |
 
 ### Error handling

--- a/examples/app/access.rs
+++ b/examples/app/access.rs
@@ -1,7 +1,7 @@
 use carapax::{
     access::{AccessExt, AccessRule, InMemoryAccessPolicy},
     types::Update,
-    Chain, HandlerResult,
+    Chain,
 };
 
 pub fn setup(chain: Chain, username: &str) -> Chain {
@@ -9,7 +9,6 @@ pub fn setup(chain: Chain, username: &str) -> Chain {
     chain.add(log_protected.access(policy))
 }
 
-async fn log_protected(update: Update) -> HandlerResult {
+async fn log_protected(update: Update) {
     log::info!("Got a new update in protected handler: {:?}", update);
-    HandlerResult::Continue
 }

--- a/src/access/predicate.rs
+++ b/src/access/predicate.rs
@@ -39,9 +39,9 @@ where
                 }
                 Ok(false) => {
                     log::info!("Access forbidden for {:?}", user);
-                    PredicateResult::False(HandlerResult::Stop)
+                    PredicateResult::False(HandlerResult::Ok)
                 }
-                Err(err) => PredicateResult::False(HandlerResult::Error(Box::new(err))),
+                Err(err) => PredicateResult::False(HandlerResult::Err(Box::new(err))),
             }
         })
     }
@@ -119,7 +119,7 @@ mod tests {
         .unwrap();
         let input_forbidden = HandlerInput::from(update_forbidden);
         let result = predicate.handle(input_forbidden).await;
-        assert!(matches!(result, PredicateResult::False(HandlerResult::Stop)));
+        assert!(matches!(result, PredicateResult::False(HandlerResult::Ok)));
 
         let update_error: Update = serde_json::from_value(serde_json::json!(
             {
@@ -136,6 +136,6 @@ mod tests {
         .unwrap();
         let input_error = HandlerInput::from(update_error);
         let result = predicate.handle(input_error).await;
-        assert!(matches!(result, PredicateResult::False(HandlerResult::Error(_))));
+        assert!(matches!(result, PredicateResult::False(HandlerResult::Err(_))));
     }
 }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -58,7 +58,7 @@ where
                 }
             };
             let future = handler.handle(input);
-            if let HandlerResult::Error(err) = future.await.into() {
+            if let HandlerResult::Err(err) = future.await.into() {
                 log::error!("An error has occurred: {}", err);
             }
         }
@@ -116,9 +116,8 @@ mod tests {
 
     impl Error for ExampleError {}
 
-    async fn success_handler(counter: Ref<Counter>) -> HandlerResult {
+    async fn success_handler(counter: Ref<Counter>) {
         *counter.value.lock().await += 1;
-        HandlerResult::Continue
     }
 
     async fn error_handler(counter: Ref<Counter>) -> Result<(), ExampleError> {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -62,17 +62,17 @@ where
                 Ok(Some(input)) => {
                     let future = handler.handle(input);
                     match future.await.into() {
-                        HandlerResult::Error(err) => {
+                        HandlerResult::Err(err) => {
                             let future = error_handler.handle(err);
-                            HandlerResult::Error(future.await)
+                            HandlerResult::Err(future.await)
                         }
                         result => result,
                     }
                 }
-                Ok(None) => HandlerResult::Continue,
+                Ok(None) => HandlerResult::Ok,
                 Err(err) => {
                     let future = error_handler.handle(Box::new(err));
-                    HandlerResult::Error(future.await)
+                    HandlerResult::Err(future.await)
                 }
             }
         })
@@ -187,7 +187,7 @@ mod tests {
         let update = create_update();
         let input = HandlerInput::from(update);
         let result = handler.handle(input).await;
-        assert!(matches!(result, HandlerResult::Error(_)));
+        assert!(matches!(result, HandlerResult::Err(_)));
         assert!(*condition.value.lock().await)
     }
 }

--- a/src/core/predicate/result.rs
+++ b/src/core/predicate/result.rs
@@ -17,7 +17,7 @@ impl From<bool> for PredicateResult {
         if value {
             PredicateResult::True
         } else {
-            PredicateResult::False(HandlerResult::Continue)
+            PredicateResult::False(HandlerResult::Ok)
         }
     }
 }
@@ -30,7 +30,7 @@ where
     fn from(value: Result<T, E>) -> Self {
         match value {
             Ok(value) => value.into(),
-            Err(err) => PredicateResult::False(HandlerResult::Error(Box::new(err))),
+            Err(err) => PredicateResult::False(HandlerResult::Err(Box::new(err))),
         }
     }
 }
@@ -54,15 +54,15 @@ mod tests {
     #[test]
     fn convert_result() {
         assert!(matches!(true.into(), PredicateResult::True));
-        assert!(matches!(false.into(), PredicateResult::False(HandlerResult::Continue)));
+        assert!(matches!(false.into(), PredicateResult::False(HandlerResult::Ok)));
         assert!(matches!(Ok::<bool, ExampleError>(true).into(), PredicateResult::True));
         assert!(matches!(
             Ok::<bool, ExampleError>(false).into(),
-            PredicateResult::False(HandlerResult::Continue)
+            PredicateResult::False(HandlerResult::Ok)
         ));
         assert!(matches!(
             Err::<bool, ExampleError>(ExampleError).into(),
-            PredicateResult::False(HandlerResult::Error(_))
+            PredicateResult::False(HandlerResult::Err(_))
         ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod ratelimit;
 #[cfg_attr(nightly, doc(cfg(feature = "session")))]
 pub mod session;
 
+#[cfg(feature = "full")]
 mod doctest {
     #![doc = include_str!("../GUIDE.md")]
 }

--- a/src/ratelimit/predicate/direct.rs
+++ b/src/ratelimit/predicate/direct.rs
@@ -88,7 +88,7 @@ impl Handler<()> for DirectRateLimitPredicate<NoJitter, MethodDiscard> {
             Ok(_) => PredicateResult::True,
             Err(_) => {
                 log::info!("DirectRateLimitPredicate: update discarded");
-                PredicateResult::False(HandlerResult::Stop)
+                PredicateResult::False(HandlerResult::Ok)
             }
         })
     }
@@ -134,7 +134,7 @@ mod tests {
             "[direct/discard/1] true"
         );
         assert!(
-            matches!(handler.handle(()).await, PredicateResult::False(HandlerResult::Stop)),
+            matches!(handler.handle(()).await, PredicateResult::False(HandlerResult::Ok)),
             "[direct/discard/2] false"
         );
 

--- a/src/ratelimit/predicate/keyed.rs
+++ b/src/ratelimit/predicate/keyed.rs
@@ -123,7 +123,7 @@ where
                 Ok(_) => PredicateResult::True,
                 Err(_) => {
                     log::info!("KeyedRateLimitPredicate: update discarded");
-                    PredicateResult::False(HandlerResult::Stop)
+                    PredicateResult::False(HandlerResult::Ok)
                 }
             }
         } else {
@@ -194,7 +194,7 @@ mod tests {
                 assert!(
                     matches!(
                         handler.handle($first_key).await,
-                        PredicateResult::False(HandlerResult::Stop)
+                        PredicateResult::False(HandlerResult::Ok)
                     ),
                     "[keyed/discard] handle({:?}) -> stop",
                     $first_key
@@ -207,7 +207,7 @@ mod tests {
                 assert!(
                     matches!(
                         handler.handle($second_key).await,
-                        PredicateResult::False(HandlerResult::Stop)
+                        PredicateResult::False(HandlerResult::Ok)
                     ),
                     "[keyed/discard] handle({:?}) -> stop",
                     $second_key
@@ -234,7 +234,7 @@ mod tests {
                 assert!(
                     matches!(
                         handler.handle($second_key).await,
-                        PredicateResult::False(HandlerResult::Stop)
+                        PredicateResult::False(HandlerResult::Ok)
                     ),
                     "[keyed/discard/with_key] handle({:?}) -> stop",
                     $first_key,


### PR DESCRIPTION
Now it contains only two variants: Ok and Err(HandlerError)
If you need Stop, use Predicate instead.