### PR TITLE
add pub access for Ref data

### DIFF
--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -44,7 +44,7 @@ impl Context {
 /// Keep in mind that each time a handler is called with `Ref<T>` as an argument,
 /// the underlying value is cloned.
 #[derive(Clone)]
-pub struct Ref<T: Clone>(T);
+pub struct Ref<T: Clone>(pub T);
 
 impl<T: Clone> Ref<T> {
     pub(super) fn new(object: T) -> Self {


### PR DESCRIPTION
Allows use data from Ref via pattern match syntax

```rust
async fn example(db: Ref<sea_orm::DatabaseConnection>) -> Result<(), AppError> {
  ...
  .exec(&*db).await?;
  ...
}
async fn example(Ref(db): Ref<sea_orm::DatabaseConnection>) -> Result<(), AppError> {
  ...
  .exec(&db).await?;
  ...
}
```